### PR TITLE
fix(readme): replace broken link to Industrial Edge Common Databus Payload Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Industrial Edge Common Databus Payload Format defines how connectors should 
 
 The official documentation can be found here under chapter "General Common Payload Format":
 
-[Industrial Edge Common Databus Payload Format](https://industrial-edge.io/developer/systemapps/data-processing/databus/reference/index.html)
+[Industrial Edge Common Databus Payload Format](https://industrial-edge.io/develop_an_application/apps/data-processing/databus/reference/index.html)
 
 ![payload_docu](docs/graphics/overview_payload_docu.png)
 


### PR DESCRIPTION
This PR fixes a broken link in the README